### PR TITLE
Finish renaming archs

### DIFF
--- a/_preload.lua
+++ b/_preload.lua
@@ -61,8 +61,8 @@
 		valid_platforms =
 		{
 			Native = "Native",
-			x32 = "Native 32-bit",
-			x64 = "Native 64-bit",
+			x86 = "Native 32-bit",
+			x86_64 = "Native 64-bit",
 			Universal32 = "32-bit Universal",
 			Universal64 = "64-bit Universal",
 			Universal = "Universal",

--- a/tests/test_xcode_project.lua
+++ b/tests/test_xcode_project.lua
@@ -1775,7 +1775,7 @@
 
 	function suite.XCBuildConfigurationProject_OnX32()
 		solution("MySolution")
-		platforms { "x32" }
+		platforms { "x86" }
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
@@ -1789,7 +1789,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/x32/Debug;
+				OBJROOT = obj/x86/Debug;
 				ONLY_ACTIVE_ARCH = NO;
 			};
 			name = Debug;
@@ -1800,7 +1800,7 @@
 
 	function suite.XCBuildConfigurationProject_OnX64()
 		solution("MySolution")
-		platforms { "x64" }
+		platforms { "x86_64" }
 		prepare()
 		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
 		test.capture [[
@@ -1814,7 +1814,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				OBJROOT = obj/x64/Debug;
+				OBJROOT = obj/x86_64/Debug;
 				ONLY_ACTIVE_ARCH = NO;
 			};
 			name = Debug;

--- a/tests/test_xcode_project.lua
+++ b/tests/test_xcode_project.lua
@@ -1773,7 +1773,7 @@
 	end
 
 
-	function suite.XCBuildConfigurationProject_OnX32()
+	function suite.XCBuildConfigurationProject_OnX86()
 		solution("MySolution")
 		platforms { "x86" }
 		prepare()
@@ -1798,7 +1798,7 @@
 	end
 
 
-	function suite.XCBuildConfigurationProject_OnX64()
+	function suite.XCBuildConfigurationProject_OnX86_64()
 		solution("MySolution")
 		platforms { "x86_64" }
 		prepare()

--- a/xcode_common.lua
+++ b/xcode_common.lua
@@ -982,8 +982,8 @@
 
 		local archs = {
 			Native = "$(NATIVE_ARCH_ACTUAL)",
-			x32    = "i386",
-			x64    = "x86_64",
+			x86    = "i386",
+			x86_64 = "x86_64",
 			Universal32 = "$(ARCHS_STANDARD_32_BIT)",
 			Universal64 = "$(ARCHS_STANDARD_64_BIT)",
 			Universal = "$(ARCHS_STANDARD_32_64_BIT)",


### PR DESCRIPTION
A number of tests were relying on the fact that x32/x64 were being converted implicitly to x86/x86_64. If/when we retire those symbols, all of those tests would break. Renamed them now to avoid having to sort it out later. Also fixed up comments to keep everything consistent.
