### PR TITLE
Fixed spaces in include dir pathes

### DIFF
--- a/xcode_common.lua
+++ b/xcode_common.lua
@@ -1045,7 +1045,7 @@
 		for i,v in ipairs(cfg.includedirs) do
 			cfg.includedirs[i] = "\""..premake.project.getrelative(cfg.project, cfg.includedirs[i]).."\""
 		end
-		settings['HEADER_SEARCH_PATHS'] = cfg.includedirs
+		settings['USER_HEADER_SEARCH_PATHS'] = cfg.includedirs
 
 		for i,v in ipairs(cfg.libdirs) do
 			cfg.libdirs[i] = premake.project.getrelative(cfg.project, cfg.libdirs[i])

--- a/xcode_common.lua
+++ b/xcode_common.lua
@@ -1043,7 +1043,7 @@
 		settings['GCC_WARN_UNUSED_VARIABLE'] = 'YES'
 
 		for i,v in ipairs(cfg.includedirs) do
-			cfg.includedirs[i] = premake.project.getrelative(cfg.project, cfg.includedirs[i])
+			cfg.includedirs[i] = "\""..premake.project.getrelative(cfg.project, cfg.includedirs[i]).."\""
 		end
 		settings['HEADER_SEARCH_PATHS'] = cfg.includedirs
 


### PR DESCRIPTION
This small change fixes the issues caused by include dirs that have spaces in their path - they are supposed to be wrapped in to ""

**Header search paths** is used to look for headers, that are included through "" and <>, **User header search paths** are used only for headers included through ""
