### PR TITLE
Fix "name in use" errors from module preload script

### DIFF
--- a/xcode.lua
+++ b/xcode.lua
@@ -12,7 +12,6 @@
 	m._VERSION = p._VERSION
 	m.elements = {}
 
-	include("_preload.lua")
 	include("xcode_common.lua")
 	include("xcode4_workspace.lua")
 	include("xcode_project.lua")


### PR DESCRIPTION
The module preloaded now uses `loadfile()` rather than `include()` in order to report script errors. As a result, the `_preload.lua` file is no longer marked as included, so subsequent calls to `include("_preload.lua")` will result in duplicated symbols.
