### PR TITLE
Correct usage of deprecated magic-variable in xcode.newid

### DIFF
--- a/xcode_common.lua
+++ b/xcode_common.lua
@@ -314,6 +314,7 @@
 
 	function xcode.newid(...)
 		local name = ''
+		local arg = {...}
 		for i, v in pairs(arg) do
 			name = name..v..'****'
 		end


### PR DESCRIPTION
The `arg` variable was used in Lua 5.0 to automatically capture
variadic arguments into a table. However, this was since deprecated,
resulting in the `pairs` function attempting to consume `nil`
and subsequently crashing.
