### PR TITLE
Added frameworkdirs option.

### DIFF
--- a/xcode_common.lua
+++ b/xcode_common.lua
@@ -1034,6 +1034,11 @@
 			cfg.libdirs[i] = premake.project.getrelative(cfg.project, cfg.libdirs[i])
 		end
 		settings['LIBRARY_SEARCH_PATHS'] = cfg.libdirs
+		
+		for i,v in ipairs(cfg.frameworkdirs) do
+			cfg.frameworkdirs[i] = premake.project.getrelative(cfg.project, cfg.frameworkdirs[i])
+		end
+		settings['FRAMEWORK_SEARCH_PATHS'] = cfg.frameworkdirs
 
 		local objDir = path.getrelative(tr.project.location, cfg.objdir)
 		settings['OBJROOT'] = objDir


### PR DESCRIPTION
This should now support FRAMEWORK_SEARCH_PATHS in xcode_common.lua. This will allow frameworks to exist in non sdk paths.

configuration "macosx"
    frameworkdirs { "Library/MacOS/SDL2-2.0.3" }
    linkoptions { "-framework SDL2" }
