### PR TITLE
Mapping includedirs and sysincludedirs to HEADER_SEARCH_PATHS

### DIFF
--- a/tests/test_xcode_project.lua
+++ b/tests/test_xcode_project.lua
@@ -1290,36 +1290,6 @@
 		]]
 	end
 
-	function suite.XCBuildConfigurationProject_OnSysIncludeDirs()
-		sysincludedirs { "../include", "../libs", "../name with spaces" }
-		prepare()
-		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
-		test.capture [[
-		[MyProject:Debug(2)] /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
-				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
-				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = (
-					../include,
-					../libs,
-					"\"../name with spaces\"",
-					"$(inherited)",
-				);
-				OBJROOT = obj/Debug;
-				ONLY_ACTIVE_ARCH = NO;
-				SYMROOT = bin/Debug;
-			};
-			name = Debug;
-		};
-		]]
-	end
 
 	function suite.XCBuildConfigurationProject_OnBuildOptions()
 		buildoptions { "build option 1", "build option 2" }

--- a/xcode_common.lua
+++ b/xcode_common.lua
@@ -1028,7 +1028,7 @@
 		for i,v in ipairs(includedirs) do
 			cfg.includedirs[i] = premake.quoted(v)
 		end
-		settings['HEADER_SEARCH_PATHS'] = cfg.includedirs
+		settings['HEADER_SEARCH_PATHS'] = table.join(cfg.includedirs, cfg.sysincludedirs)
 
 		for i,v in ipairs(cfg.libdirs) do
 			cfg.libdirs[i] = premake.project.getrelative(cfg.project, cfg.libdirs[i])

--- a/xcode_common.lua
+++ b/xcode_common.lua
@@ -1030,15 +1030,6 @@
 		end
 		settings['USER_HEADER_SEARCH_PATHS'] = cfg.includedirs
 
-		local sysincludedirs = project.getrelative(cfg.project, cfg.sysincludedirs)
-		for i,v in ipairs(sysincludedirs) do
-			cfg.sysincludedirs[i] = premake.quoted(v)
-		end
-		if not table.isempty(cfg.sysincludedirs) then
-			table.insert(cfg.sysincludedirs, "$(inherited)")
-		end
-		settings['HEADER_SEARCH_PATHS'] = cfg.sysincludedirs
-
 		for i,v in ipairs(cfg.libdirs) do
 			cfg.libdirs[i] = premake.project.getrelative(cfg.project, cfg.libdirs[i])
 		end

--- a/xcode_common.lua
+++ b/xcode_common.lua
@@ -1028,7 +1028,7 @@
 		for i,v in ipairs(includedirs) do
 			cfg.includedirs[i] = premake.quoted(v)
 		end
-		settings['USER_HEADER_SEARCH_PATHS'] = cfg.includedirs
+		settings['HEADER_SEARCH_PATHS'] = cfg.includedirs
 
 		for i,v in ipairs(cfg.libdirs) do
 			cfg.libdirs[i] = premake.project.getrelative(cfg.project, cfg.libdirs[i])


### PR DESCRIPTION
Currently, the includedirs option maps to USER_HEADER_SEARCH_PATHS (clang's -iquote option) and sysincludedirs maps to HEADER_SEARCH_PATHS (clang's -I option).

This causes all headers with angled brackets, ie. #include &lt;SomeHeader.h&gt; to be not recognized on the search path when specified with the "includedir" option in premake5.

I've reverted the sysincludedirs changes and remapped includedirs and sysincludedirs to map to HEADER_SEARCH_PATHS ( -I option ) as that seems to be the expected behaviour.
