### PR TITLE
set C++ standard for C++11/C++14 flags

### DIFF
--- a/xcode_common.lua
+++ b/xcode_common.lua
@@ -989,6 +989,12 @@
 
 		settings['GCC_C_LANGUAGE_STANDARD'] = 'gnu99'
 
+		if cfg.flags['C++14'] then
+			settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++14'
+		elseif cfg.flags['C++11'] then
+			settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++0x'
+		end
+
 		if cfg.exceptionhandling == p.OFF then
 			settings['GCC_ENABLE_CPP_EXCEPTIONS'] = 'NO'
 		end


### PR DESCRIPTION
set C++ standard for C++11/C++14 flags. C++14 wins over C++11. While "c++11" as string _should_ be working too I'm using "c++0x" here as this is the string that is being used when selecting "C++11" in the drop down from within Xcode.
