### PR TITLE
Fixed symbols output

### DIFF
--- a/tests/test_xcode_project.lua
+++ b/tests/test_xcode_project.lua
@@ -1021,6 +1021,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CONFIGURATION_BUILD_DIR = bin/Debug;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = MyProject;

--- a/xcode_common.lua
+++ b/xcode_common.lua
@@ -884,7 +884,7 @@
 
 		settings['ALWAYS_SEARCH_USER_PATHS'] = 'NO'
 
-		if not (cfg.symbols == p.ON) then
+		if cfg.symbols ~= p.OFF then
 			settings['DEBUG_INFORMATION_FORMAT'] = 'dwarf-with-dsym'
 		end
 
@@ -983,7 +983,8 @@
 
 		settings['CONFIGURATION_TEMP_DIR'] = '$(OBJROOT)'
 
-		if cfg.symbols == p.ON then
+		local isOptimized = config.isOptimizedBuild(cfg)
+		if cfg.symbols == p.ON and not isOptimized then
 			settings['COPY_PHASE_STRIP'] = 'NO'
 		end
 

--- a/xcode_common.lua
+++ b/xcode_common.lua
@@ -983,8 +983,7 @@
 
 		settings['CONFIGURATION_TEMP_DIR'] = '$(OBJROOT)'
 
-		local isOptimized = config.isOptimizedBuild(cfg)
-		if cfg.symbols == p.ON and not isOptimized then
+		if config.isDebugBuild(cfg) then
 			settings['COPY_PHASE_STRIP'] = 'NO'
 		end
 


### PR DESCRIPTION
Symbols "On" was yielding nothing, due to a bug in the code.
Plus you want to have symbols for release builds, but you want to strip your release binary for distribution, so that's fixed as well
