### PR TITLE
Revert "Merge pull request #26 from soundsrc/include-dir-fix"

### DIFF
--- a/tests/test_xcode_project.lua
+++ b/tests/test_xcode_project.lua
@@ -1291,6 +1291,36 @@
 		]]
 	end
 
+	function suite.XCBuildConfigurationProject_OnSysIncludeDirs()
+		sysincludedirs { "../include", "../libs", "../name with spaces" }
+		prepare()
+		xcode.XCBuildConfiguration_Project(tr, tr.configs[1])
+		test.capture [[
+		[MyProject:Debug(2)] /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
+				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					../include,
+					../libs,
+					"\"../name with spaces\"",
+					"$(inherited)",
+				);
+				OBJROOT = obj/Debug;
+				ONLY_ACTIVE_ARCH = NO;
+				SYMROOT = bin/Debug;
+			};
+			name = Debug;
+		};
+		]]
+	end
 
 	function suite.XCBuildConfigurationProject_OnBuildOptions()
 		buildoptions { "build option 1", "build option 2" }

--- a/xcode_common.lua
+++ b/xcode_common.lua
@@ -1034,7 +1034,16 @@
 		for i,v in ipairs(includedirs) do
 			cfg.includedirs[i] = premake.quoted(v)
 		end
-		settings['HEADER_SEARCH_PATHS'] = table.join(cfg.includedirs, cfg.sysincludedirs)
+		settings['USER_HEADER_SEARCH_PATHS'] = cfg.includedirs
+
+		local sysincludedirs = project.getrelative(cfg.project, cfg.sysincludedirs)
+		for i,v in ipairs(sysincludedirs) do
+			cfg.sysincludedirs[i] = premake.quoted(v)
+		end
+		if not table.isempty(cfg.sysincludedirs) then
+			table.insert(cfg.sysincludedirs, "$(inherited)")
+		end
+		settings['HEADER_SEARCH_PATHS'] = cfg.sysincludedirs
 
 		for i,v in ipairs(cfg.libdirs) do
 			cfg.libdirs[i] = premake.project.getrelative(cfg.project, cfg.libdirs[i])


### PR DESCRIPTION
Based on our discussions https://github.com/premake/premake-xcode/pull/26, I'm requesting the revert of merge #26 as it lost an important unit test and caused a spacing bug in the process.

I still think that the includedir and sysincludedir usage in the Xcode project is still up for debate on the correct behaviour, but I think restoring the previous functionality first and then carefully revisiting the specs later before making any major decisions.
